### PR TITLE
Allow for questions to be deleted via the UI

### DIFF
--- a/survey-app/app.js
+++ b/survey-app/app.js
@@ -86,7 +86,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 // Routes
 require('./routes/api')(app, dbController);
-require('./routes/views')(app);
+require('./routes/views')(app, dbController);
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {

--- a/survey-app/lib/database.js
+++ b/survey-app/lib/database.js
@@ -4,6 +4,7 @@
  * promises at some point
  **/
 
+const Hashids = require('hashids');
 const sequelize = require('sequelize');
 
 module.exports = (function () {
@@ -31,6 +32,7 @@ module.exports = (function () {
      *  @param {Array.<String>} answers - The answers
      * @return {Object} - Question Info
      *  @param {Number} id - Question ID; Will be blank on failure
+     *  @param {Number} admin_key - The user administration key; Will be blank on failure
      */
     createQuestion(questionData, callback) {
       sequelize.Promise.resolve({}).then(() => {
@@ -42,7 +44,10 @@ module.exports = (function () {
           });
         })
         .then(() => {
-          callback({ id: this.question.id });
+          callback({
+            id: this.question.id,
+            admin_key: new Hashids('survey time', 10).encode(this.question.id),
+          });
         }).
         catch((error) => {
           logError(error);
@@ -73,6 +78,7 @@ module.exports = (function () {
      * @return {Array.Object} or {Object} - Array of objects containing the survey
      *  questions and answers. The array will be empty if no questions are found
      *  @param {Number} qid - The question ID
+     *  @param {Number} admin_key - The user administration key
      *  @param {String} question - The question
      *  @param {Number} total_responses - The total number of responses to the current question
      *  @param {Array.<Object>} - Answer data
@@ -84,6 +90,7 @@ module.exports = (function () {
       function formatQuestionData(questions) {
         return questions.map((question) => ({
           id: question.id,
+          admin_key: new Hashids('survey time', 10).encode(question.id),
           question: question.dataValues.question,
           total_responses: question.dataValues.total_responses,
           answers: question.dataValues.answers.map((a) => a.dataValues),

--- a/survey-app/package.json
+++ b/survey-app/package.json
@@ -17,6 +17,7 @@
     "gulp-minify-css": "*",
     "gulp-sass": "*",
     "gulp-uglify": "*",
+    "hashids": "^1.1.0",
     "jade": "*",
     "js-cookie": "*",
     "morgan": "^1.7.0",

--- a/survey-app/public/stylesheets/style.css
+++ b/survey-app/public/stylesheets/style.css
@@ -116,23 +116,24 @@ textarea:focus, input:focus {
     box-align: center; }
     .container-fluid .content h2 {
       margin: auto; }
-  .container-fluid .create-question, .container-fluid .question-results {
+  .container-fluid .administer-question, .container-fluid .create-question, .container-fluid .question-results {
     width: 100%; }
-    .container-fluid .create-question .message, .container-fluid .question-results .message {
+    .container-fluid .administer-question .message, .container-fluid .create-question .message, .container-fluid .question-results .message {
       margin: 0 auto;
       margin-bottom: 5rem; }
-    .container-fluid .create-question .form-group, .container-fluid .question-results .form-group {
+    .container-fluid .administer-question .form-group, .container-fluid .create-question .form-group, .container-fluid .question-results .form-group {
       width: inherit; }
-    .container-fluid .create-question #question-url input, .container-fluid .question-results #question-url input {
+    .container-fluid .administer-question #question-url input, .container-fluid .create-question #question-url input, .container-fluid .question-results #question-url input {
       background: #153a51;
       border: none;
       color: #5BC3EB; }
-    .container-fluid .create-question #question-url #copy-button, .container-fluid .create-question #question-url .input-group-btn, .container-fluid .question-results #question-url #copy-button, .container-fluid .question-results #question-url .input-group-btn {
+    .container-fluid .administer-question #question-url #copy-button, .container-fluid .administer-question #question-url .input-group-btn, .container-fluid .create-question #question-url #copy-button, .container-fluid .create-question #question-url .input-group-btn, .container-fluid .question-results #question-url #copy-button, .container-fluid .question-results #question-url .input-group-btn {
       background: #5BC3EB;
       border: none;
       color: #153a51;
-      font-weight: 300; }
-    .container-fluid .create-question #view-result, .container-fluid .question-results #view-result {
+      font-weight: 300;
+      margin: 0; }
+    .container-fluid .administer-question .btn, .container-fluid .create-question .btn, .container-fluid .question-results .btn {
       margin-top: 5rem;
       width: 100%; }
   .container-fluid .question {
@@ -165,12 +166,12 @@ textarea:focus, input:focus {
   .container-fluid .question-results.list .question-container {
     margin-bottom: 5vh;
     padding: 2.5vh; }
+  .container-fluid .question-results.list h2 {
+    font-size: 1.5em; }
   .container-fluid .question-results .question-container {
     width: 100%; }
     .container-fluid .question-results .question-container .question {
       margin-bottom: 4vh; }
-      .container-fluid .question-results .question-container .question h2 {
-        font-size: 1.5em; }
     .container-fluid .question-results .question-container .answer {
       background: #153a51;
       padding: 0;
@@ -210,13 +211,17 @@ textarea:focus, input:focus {
         position: relative; }
   .container-fluid .form-group {
     margin: 0; }
-    .container-fluid .form-group .question-field, .container-fluid .form-group .answer-field, .container-fluid .form-group .add-answer {
+    .container-fluid .form-group .question-field {
+      margin-bottom: 5vh; }
+    .container-fluid .form-group .answer-field, .container-fluid .form-group .add-answer {
       margin-bottom: 3vh; }
+    .container-fluid .form-group .answer-field:last-child {
+      margin-bottom: 0; }
 
-.add-answer, #view-result {
+.form-btn {
   background-color: #1E5171;
   font-weight: 300; }
-  .add-answer:hover, #view-result:hover {
+  .form-btn:hover, .form-btn:focus {
     color: #5BC3EB; }
 
 .bottom-button-fill {

--- a/survey-app/public/stylesheets/style.scss
+++ b/survey-app/public/stylesheets/style.scss
@@ -104,7 +104,7 @@ textarea:focus, input:focus {
       margin:auto;
     }
   }
-  .create-question, .question-results {
+  .administer-question, .create-question, .question-results {
     width:100%;
 
     .message {
@@ -129,10 +129,11 @@ textarea:focus, input:focus {
         border:none;
         color:$background-color-med;
         font-weight:$header-font-weight;
+        margin:0;
       }
     }
     
-    #view-result {
+    .btn {
       margin-top:5rem;
       width:100%;
     }
@@ -179,20 +180,18 @@ textarea:focus, input:focus {
         margin-bottom:5vh;
         padding:2.5vh;
       }
-    }
+      h2 {
+        font-size:1.5em;
+      }
+  }
 
     .question-container {
       //background:$background-color-light; 
       //padding:2.5vh;
       width:100%;
 
-
       .question {
         margin-bottom:4vh;        
- 
-        h2 {
-          font-size:1.5em;
-        }
       }
       .answer {
         background:$background-color-med;
@@ -241,16 +240,22 @@ textarea:focus, input:focus {
   .form-group {
     margin:0;
 
-    .question-field, .answer-field, .add-answer {
+    .question-field {
+      margin-bottom:5vh;
+    }
+    .answer-field, .add-answer {
       margin-bottom:3vh;
+    }
+    .answer-field:last-child {
+      margin-bottom:0;
     }
   }
 }
-.add-answer, #view-result {
+.form-btn {
   background-color:$background-color-light;
   font-weight:$header-font-weight;
 
-  &:hover {
+  &:hover, &:focus {
     color:$secondary-color;
   }
 }

--- a/survey-app/routes/views.js
+++ b/survey-app/routes/views.js
@@ -4,33 +4,54 @@
  *
  **/
 
-module.exports = (app) => {
+const Hashids = require('hashids');
+
+module.exports = (app, dbController) => {
   /**
    * Main view (survey questions)
    **/
   app.get('/', (req, res) =>
-    res.render('create-question', { title: 'Survey Time' })
+    res.render('create-question')
   );
+
 
   /**
    * Add question view
    **/
-  app.get('/create-question', (req, res) =>
-    res.render('create-question', { title: 'Create Question' })
+  app.get('/create', (req, res) =>
+    res.render('create-question')
   );
+
+
+  /**
+   * Administer a question
+   **/
+  app.get('/admin/:adminKey', (req, res) => {
+    const qID = new Hashids('survey time', 10).decode(req.params.adminKey);
+    dbController.getQuestion({ qid: qID }, (questions, err) => {
+      if (questions.length > 0 && !err) {
+        const qURL = `${req.protocol}://${req.get('host')}/question/${qID}`;
+        res.render('administer-question', { qID, qURL });
+      } else {
+        res.render('404');
+      };
+    });
+  });
+
 
   /**
    * Get a specific question by it's world-readable ID
    **/
-  app.get('/question/:questionID', (req, res) =>
-     res.render('answer-question', { title: 'Survey Time', qid: req.params.questionID })
-  );
+  app.get('/question/:qID', (req, res) => {
+    res.render('answer-question', { qID: req.params.qID });
+  });
+
 
   /**
-   * Get a specific question by it's world-readable ID
+   * Get a random question
    **/
   app.get('/question/random', (req, res) =>
-     res.render('answer-question', { title: 'Survey Time', qid: req.params.questionID })
+     res.render('answer-question', { qID: req.params.qID })
   );
 
 
@@ -42,6 +63,7 @@ module.exports = (app) => {
   });
   **/
 
+
   /**
    * Logout page
    * NOTE: Currently unused
@@ -50,24 +72,27 @@ module.exports = (app) => {
   });
   **/
 
+
   /**
    * All survey results
    **/
   app.get('/results/list', (req, res) =>
-    res.render('results-list', { title: 'All Questions' })
+    res.render('results-list')
   );
+
 
   /**
    * View results view (single)
    **/
   app.get('/results/:questionID', (req, res) =>
-    res.render('single-results', { title: 'View Question Results' })
+    res.render('single-results')
   );
+
 
   /**
    * 404 page
    **/
   app.get('*', (req, res) =>
-    res.render('404', { title: 'Survey Time' })
+    res.render('404')
   );
 };

--- a/survey-app/views/administer-question.jade
+++ b/survey-app/views/administer-question.jade
@@ -1,0 +1,11 @@
+extends layout.jade
+block internals
+  div.content.administer-question.row
+    h2.message Here's a link to your question:
+    form
+      #question-url.input-group
+        input#copy-input.form-control.input-lg(type="text", value="#{qURL}", placeholder="Question URL")
+        span.input-group-btn
+          button#copy-button.btn.btn-lg(type="button" data-placement="button", title="Copy to Clipboard") Copy Link
+      button#view-result.btn.btn-lg.form-btn(type="button", data-placement="button", data-question-id="#{qID}", title="View Results") View Results
+      button#delete-question.btn.btn-lg.form-btn(type="button", data-placement="button", data-question-id="#{qID}", title="Delete Question") Delete Question

--- a/survey-app/views/answer-question.jade
+++ b/survey-app/views/answer-question.jade
@@ -1,6 +1,6 @@
 extends layout.jade 
 block internals
-  div.content.question-answer.row
+  div.content.answer-question.row
     div.question
     div.answers
   div.bottom-button-fill

--- a/survey-app/views/create-question.jade
+++ b/survey-app/views/create-question.jade
@@ -4,11 +4,9 @@ block internals
   div.content.create-question
     div.question.form-group
       textarea(type="text", name="question", placeholder="Enter a question here...", class="question-field form-control input-lg", rows="3")
-    br
     div.answers.form-group
       input(type="text", name="answer[]", placeholder="Add an answer here...", class="answer-field form-control input-lg")  
-    br
-    button(type="text", name="addAnswer", class="add-answer btn btn-secondary btn-block btn-lg") Add Another Answer
+    button#add-answer.btn.btn-lg.form-btn(type="text", name="addAnswer") Add Another Answer
  
   div.bottom-button-fill
   div.bottom-button-container


### PR DESCRIPTION
Users must be able to delete survery questions when applicable.
This commit allows users to delete questions via a 'question
administation' (QA) page. A unique, 10+ digit URL is generated
for each QA page in order to prevent random users from deleting
questions (generated via Hashids). The 'create question' API
now return this administration key alongside the question ID.

The POST and PUT question APIs were erroneously switched (PUT
was used for question creation POST was used for question
modifications). This commit resolves that mistake. In addition,
all API endpoints are now prefixed with '/api/' in order to
reduce namespace collisions.
